### PR TITLE
Fix display difference in tend and sow lines

### DIFF
--- a/esrc/search.php
+++ b/esrc/search.php
@@ -272,7 +272,8 @@ if (isset($targetsystem)) {
 			}
 			echo '<tr>';
 			// add 4 hours to convert to UTC (EVE) for display
-			$rowdate = (!empty($sowrow)) ? $sowrow['InitialSeedDate'] : $value['ActivityDate'];
+// 			$rowdate = (!empty($sowrow)) ? $sowrow['InitialSeedDate'] : $value['ActivityDate'];
+			$rowdate = $value['ActivityDate'];
 			echo '<td class="white text-nowrap">'. Output::getEveDate($rowdate) .'</td>';
 			echo '<td class="text-nowrap">'. $value['Pilot'] .'</td>';
 			echo '<td class="white" '. $actioncellformat .'>'. $value['EntryType'] .'</td>';


### PR DESCRIPTION
- do not use the dates from different sources
- InitialSeedDate does not provide a time information
- display all activity dates in cache info from activities

Note: Please check the change with the system mentioned in #99 . I can not reproduce the issue on my test system without manual data manipulation. But it's late.

I did not add the "Closes" reference to the PR. Leae open till the test is successful.