### PR TITLE
Tend time handling rechecked/reworked

### DIFF
--- a/class/caches.class.php
+++ b/class/caches.class.php
@@ -125,7 +125,7 @@ class Caches
 	/**
 	 * Check if a cache is allowed to be tender
 	 * @param unknown $system the system to check
-	 * @return void|mixed 0 - cache is not allowed to be tendet; 1- cache can be tended
+	 * @return void|mixed 0 - cache is not allowed to be tendet; 1 - cache can be tended
 	 */
 	public function isTendingAllowed($system)
 	{
@@ -136,7 +136,7 @@ class Caches
 		}
 
 		// select 0/1 from cache if time diff is >= 24 hours
-		$this->db->query("SELECT count(1) as cnt FROM cache WHERE System = :system AND Status <> 'Expired' and (time_to_sec(timediff(CURRENT_TIMESTAMP(), LastUpdated)) / 3600) >= 24");
+		$this->db->query("SELECT count(1) as cnt FROM cache WHERE System = :system AND (Status = 'Healthy' and (time_to_sec(timediff(CURRENT_TIMESTAMP(), LastUpdated)) / 3600) >= 24) or (status = 'Upkeep Required' and ExpiresOn > CURRENT_DATE)");
 		$this->db->bind(':system', $system);
 		
 		$result = $this->db->single();

--- a/esrc/modal_tend.php
+++ b/esrc/modal_tend.php
@@ -35,8 +35,18 @@
 				<label class="control-label" for="status">Status</label>
 				<div class="radio">
 					<label for="status_1">
-						<input id="status_1" name="status" type="radio" value="Healthy">
-						<strong>Healthy</strong> = Anchored, safe, and full of supplies
+						<input id="status_1" name="status" type="radio" value="Healthy" <?php if (0 == $caches->isTendingAllowed($targetsystem)) {echo ' disabled="disabled" '; } ?> >
+						<?php if (1 == $caches->isTendingAllowed($targetsystem)) { ?>
+							<strong>Healthy</strong> = Anchored, safe, and full of supplies
+						<?php 
+						}
+						else 
+						{
+						?>
+							Tended within the last 24 hours.
+						<?php 
+						}
+						?>
 					</label>
 				</div>
 				<div class="radio">

--- a/esrc/search.php
+++ b/esrc/search.php
@@ -86,7 +86,7 @@ if (!empty($errmsg)) {
 }
 
 // check if a system is supplied
-if (isset($targetsystem)) {
+if (isset($targetsystem) && trim($targetsystem) != '') {
 	// display result for the selected system
 	// get cache information from database
 	$row = $caches->getCacheInfo($targetsystem);

--- a/esrc/search.php
+++ b/esrc/search.php
@@ -115,12 +115,8 @@ if (isset($targetsystem) && trim($targetsystem) != '') {
 		<div class="col-sm-12">
 		<div style="padding-left: 10px;">
 		<!-- TEND button -->
-		<?php if ($caches->isTendingAllowed($targetsystem)) { ?>
 		<button type="button" class="btn btn-primary" role="button" data-toggle="modal" 
 			data-target="#TendModal">Tend</button>&nbsp;&nbsp;&nbsp;
-		<?php } else { ?>
-		<span class="white"><b>No tending needed</b></span>&nbsp;&nbsp;&nbsp;
-		<?php  } ?>
 		<!-- AGENT button -->
 		<button type="button" class="btn btn-warning" role="button" data-toggle="modal" 
 			data-target="#AgentModal">Agent</button>&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
- allow tending all the time
- disable healthy tend within 24 hours of last tending

Side change:
- No error about an invalid system name is displayed anymore if search without a value or spaces only
- displays the statistics page now

Closes #74 
