### PR TITLE
Secure access to copilot data provider

### DIFF
--- a/data/copilot.php
+++ b/data/copilot.php
@@ -14,9 +14,21 @@ include_once '../class/db.class.php';
 include_once '../class/systems.class.php';
 include_once '../class/caches.class.php';
 
-$cache = strtoupper ( $_REQUEST ["cache"] );
-
 try {
+	$cache = strtoupper ( $_REQUEST ["cache"] );
+	
+	session_start();
+	
+	if (session_status() != PHP_SESSION_ACTIVE || !isset($_SESSION['auth_copilot']))
+	{
+		$result['authorized'] = "Invalid session. Disabled or not allowed for copilot";
+// 		throw new Exception ( "Invalid session" );
+	}
+	else 
+	{
+		$result['authorized'] = 1;
+	}
+	
 	$db = new Database ();
 	
 	$systems = new Systems($db);
@@ -61,7 +73,7 @@ try {
 		
 		$result['tending'] = $caches->isTendingAllowed($cache);
 		
-// debug data structure
+// 		debug data structure
 // 		print_r($result);
 	} // $cache not present or wrong format
 else {
@@ -69,13 +81,13 @@ else {
 	}
 } catch ( Exception $e ) {
 	$errorMsg = $e->getMessage ();
-	if (($errorMsg != "invalid") && ($errorMsg != "none") || ! isset ( $errorMsg )) {
+// 	if (($errorMsg != "invalid") && ($errorMsg != "none") || ! isset ( $errorMsg )) {
 		// echo "error";
 		$result ['error'] = $errorMsg;
-	} else {
-		$result ['error'] = $errorMsg;
-		// echo 'Msg: '.$errorMsg;
-	}
+// 	} else {
+// 		$result ['error'] = $errorMsg;
+// 		// echo 'Msg: '.$errorMsg;
+// 	}
 }
 
 echo json_encode ( $result );


### PR DESCRIPTION
- check for session
- start session before check value
- add a result field "authorized" to response json

Remove the comment from the "throw new Exception ( "Invalid session" );" if working to disable access. Current implementation added logging only. This way the Copilot is not broken if things may go wrong..

The authorized field may be removed if not necessary, Just for debug/log purpose.