### PR TITLE
Limit SAR request display

### DIFF
--- a/class/rescue.class.php
+++ b/class/rescue.class.php
@@ -60,7 +60,6 @@ class Rescue {
 		$this->db->execute();
 		// get new rescue ID
 		$rescueID = $this->db->lastInsertId();
-		// 	echo "<br> Creaded request: ".$rescueID.": Note:".$data['notes']."<br>";
 	
 		// return the new created rescue ID
 		return $rescueID;
@@ -159,36 +158,40 @@ class Rescue {
 		$this->db->bind(":finished", $finished);
 		// $database->execute();
 		$data = $this->db->resultset();
-// 		 echo "<pre>";
-// 		 print_r($database);
-// 		 echo "\n";
-// 		 print_r($data);
-// 		 echo "</pre>";
 		$this->db->closeQuery();
 		
 		return $data;
 	}
 	
 	/**
-	 * Get single request by system
+	 * Get all requests by system
+	 * @param number $system - find request for the system
 	 * @param number $finished 0 - all open requests (default); 1 - all finished requests
+	 * @param number $isCoord 0 - returns only open requests if search for open requests (default); 1 - returns all requests if search for open requests
 	 * @return array
 	 */
-	public function getSystemRequests($system, $finished)
+	public function getSystemRequests($system, $finished = 0, $isCoord = 0)
 	{
-		// get requests from database
-		$this->db->query("SELECT * FROM rescuerequest 
+		// set the default query
+		$sql = "SELECT * FROM rescuerequest 
 							WHERE system = :system and finished = :finished
-							ORDER BY requestdate DESC");
+							ORDER BY requestdate DESC";
+		
+		// check if search for open requests and user is NOT coordinator/admin
+		if ($finished == 0 && $isCoord == 0)
+		{
+			// select only open requests
+			$sql = "SELECT * FROM rescuerequest
+							WHERE system = :system and finished = :finished and status in( 'open', 'system-located')
+							ORDER BY requestdate DESC";
+		}
+		
+		// get requests from database
+		$this->db->query($sql);
 		$this->db->bind(":system", $system);
 		$this->db->bind(":finished", $finished);
 		// $database->execute();
 		$data = $this->db->resultset();
-// 		 echo "<pre>";
-// 		 print_r($database);
-// 		 echo "\n";
-// 		 print_r($data);
-// 		 echo "</pre>";
 		$this->db->closeQuery();
 		
 		return $data;
@@ -205,15 +208,9 @@ class Rescue {
 							WHERE rescueid = :rescueid ORDER BY notedate DESC");
 		$this->db->bind(":rescueid", $requestID);
 		$data = $this->db->resultset();
-		// 		 echo "<pre>";
-		// 		 print_r($database);
-		// 		 echo "\n";
-		// 		 print_r($data);
-		// 		 echo "</pre>";
 		$this->db->closeQuery();
 		
 		return $data;
 	}
-
 }
 ?>

--- a/data/copilot.php
+++ b/data/copilot.php
@@ -13,6 +13,7 @@ define('ESRC', TRUE);
 include_once '../class/db.class.php';
 include_once '../class/systems.class.php';
 include_once '../class/caches.class.php';
+include_once '../class/rescue.class.php';
 
 try {
 	$cache = strtoupper ( $_REQUEST ["cache"] );
@@ -33,6 +34,7 @@ try {
 	
 	$systems = new Systems($db);
 	$caches = new Caches($db);
+	$rescue = new Rescue($db);
 	
 	if ($cache && strlen ( $cache ) == 7) {
 		// check for "No Sow" system
@@ -62,14 +64,11 @@ try {
 		}
 		// echo json_encode($row);
 		$result ['cache'] = $row;
-		
-		$db->query ( "SELECT count(1) as cnt
- 						FROM rescuerequest
- 						WHERE system = :system and finished = 0" );
-		$db->bind ( ':system', $cache );
-		$row = $db->single ();
+		// report only open requests
+		$requests = $rescue->getSystemRequests($cache, 0);
 		// echo json_encode($row);
-		$result ['rescue'] = $row['cnt'];
+// 		$result ['rescue'] = $row['cnt'];
+		$result ['rescue'] = count($requests);
 		
 		$result['tending'] = $caches->isTendingAllowed($cache);
 		

--- a/esrc/rescueoverview.php
+++ b/esrc/rescueoverview.php
@@ -206,11 +206,21 @@ function displayLine($row, $finished = 0, $system = NULL, $notes = 0, $isCoord =
 		echo '<td><a type="button" class="btn btn-danger" role="button" href="?sys='.
 				$row['system'].'&amp;req='.$row['id'].'">Update</a></td>';
 	}
+	// display request date
 	echo "<td>".Output::getEveDate($row['requestdate'])."</td>";
+	// display system information
 	echo (!empty($system)) ? '' : '<td><a href="?sys='.$row['system'].'">'.
 			Output::htmlEncodeString($row['system']).'</a></td>';
-	echo '<td><a target="_blank" href="https://gate.eveonline.com/Profile/'. 
-			$row['pilot'] .'">'.Output::htmlEncodeString($row['pilot']).'</a></td>';
+	// display pilot information
+	if ($isCoord == 0 && $finished == 1)
+	{
+		echo '<td><b>PROTECTED</b></td>';
+	}
+	else
+	{
+		echo '<td><a target="_blank" href="https://gate.eveonline.com/Profile/'. 
+				$row['pilot'] .'">'.Output::htmlEncodeString($row['pilot']).'</a></td>';
+	}
 	// set status color
 	switch ($status) {
 		case 'new':
@@ -269,11 +279,11 @@ if (!empty($system)) {
 	<div class="ws"></div>
 	
 	<?php // get active requests from database
-	$data = $rescue->getSystemRequests($system, 0);
+	$data = $rescue->getSystemRequests($system, 0, $isCoord);
 	displayTable($data, 0, $system, 1, $isCoord);
 	
 	// get finished requests from database
-	$data = $rescue->getSystemRequests($system, 1);
+	$data = $rescue->getSystemRequests($system, 1, $isCoord);
 	displayTable($data, 1, $system, 0, $isCoord);
 	}
 	// invalid system name


### PR DESCRIPTION
- display only active SAR requests to pilots (open, system located)
- display all SAR requests to SAR coordinators
- hide pilots name of closed SAR requests, except for SAR coordinators
- adjust copilot data provider to match display limitations
- adjust docu of rescue class
- remove lot of debug code (coude should stay clean)
- add encoding of pilot names on statistics page

References: #151 , #149 