### PR TITLE
Fix redirect target for calls without a session

### DIFF
--- a/auth/login.php
+++ b/auth/login.php
@@ -12,8 +12,11 @@ if (isset($_SESSION['auth_characterid'])) {
     exit;
 } 
 else {
-	
- 	$_SESSION['auth_redirect']=Config::ROOT_PATH;
+	// check if a session redirect PATH is already set
+	if (!isset($_SESSION['auth_redirect'])) {
+		// no, set a default redirect path
+		$_SESSION['auth_redirect']=Config::ROOT_PATH;
+	}
 	$authsite='https://login.eveonline.com';
     $authurl='/oauth/authorize';
     $state=uniqid();

--- a/esrc/rescueoverview.php
+++ b/esrc/rescueoverview.php
@@ -11,10 +11,26 @@ include_once '../class/config.class.php';
 // check if the user is alliance member
 if (!Users::isAllianceUserSession())
 {
+	// check if last login was already a non auth user
+	if (isset($_SESSION['AUTH_NOALLIANCE']))
+	{
+		// set redirect to root path
+		$_redirect_uri = Config::ROOT_PATH;	
+	}
+	else
+	{
+		// set redirect to requested path
+		$_redirect_uri = $_SERVER['REQUEST_URI'];
+	}
+	
 	// void the session entries on 'attack'
 	session_unset();
+	// save the redirect URL to current page
+	$_SESSION['auth_redirect']=$_redirect_uri;
+	// set a flag for alliance user failure
+	$_SESSION['AUTH_NOALLIANCE'] = 1;
 	// no, redirect to home page
-	header("Location: ".Config::ROOT_PATH);
+	header("Location: ".Config::ROOT_PATH."auth/login.php");
 	// stop processing
 	exit;
 }

--- a/esrc/search.php
+++ b/esrc/search.php
@@ -11,10 +11,26 @@ include_once '../class/config.class.php';
 // check if the user is alliance member
 if (!Users::isAllianceUserSession())
 {
+	// check if last login was already a non auth user
+	if (isset($_SESSION['AUTH_NOALLIANCE']))
+	{
+		// set redirect to root path
+		$_redirect_uri = Config::ROOT_PATH;
+	}
+	else
+	{
+		// set redirect to requested path
+		$_redirect_uri = $_SERVER['REQUEST_URI'];
+	}
+
 	// void the session entries on 'attack'
 	session_unset();
+	// save the redirect URL to current page
+	$_SESSION['auth_redirect']=$_redirect_uri;
+	// set a flag for alliance user failure
+	$_SESSION['AUTH_NOALLIANCE'] = 1;
 	// no, redirect to home page
-	header("Location: ".Config::ROOT_PATH);
+	header("Location: ".Config::ROOT_PATH."auth/login.php");
 	// stop processing
 	exit;
 }


### PR DESCRIPTION
* search.php and rescueoverview supports correct redirect target
* process_sow|tend|agent and rescueaction pages redirect to homepage
* login with non corp char redirects to homepage