### PR TITLE
Limiting planets selectable when sowing cache

### DIFF
--- a/class/systems.class.php
+++ b/class/systems.class.php
@@ -267,7 +267,27 @@ class Systems {
 		//end db transaction
 		$this->db->endTransaction();
 	}
-	
+
+	/**
+	 * Get valid sow locations for system
+	 * @param unknown $system
+	 * @return string array
+	 */
+	public function getSowLocations($system)
+	{
+		$sowLocs = array('See Notes','Star',
+			'I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX');
+
+		$whInfo = $this->getWHInfo($system);
+		if (isset($whInfo['PlanetCount'])) 
+		{
+			$nonPlanetOptions = 2;
+			$planetCount = $whInfo['PlanetCount'];
+			$sowLocs = array_slice($sowLocs, 0, $nonPlanetOptions + $planetCount);
+		}
+
+		return $sowLocs;
+	}
 }
 
 ?>

--- a/esrc/modal_edit.php
+++ b/esrc/modal_edit.php
@@ -81,7 +81,7 @@ if (isset($_POST['sys_edit'])) {
 } // end form POST processing
 
 // array for Location and AlignedWith select lists
-$locopts = array('See Notes','Star','I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX');
+$locopts = $systems_top->getSowLocations($system);
 ?>
 
 <div id="EditModal" class="modal fade" role="dialog">

--- a/esrc/modal_sow.php
+++ b/esrc/modal_sow.php
@@ -1,7 +1,7 @@
 <!-- Sower Modal Form -->
 
 <?php 
-$locopts = array('See Notes','Star','I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX');
+$locopts = $systems_top->getSowLocations($system);
 ?>
 <div id="SowModal" class="modal fade" role="dialog">
   <div class="modal-dialog">


### PR DESCRIPTION
Addresses issue  #215

Returns right number of options if 'PlanetCount' is available from wh_systems, otherwise the standard default.

I wasn't sure exactly where to put the function - I'm still finding my feet with the php stuff but putting code into the modal_sow file felt a bit untidy, however the systems class is very db focused.