### PR TITLE
Enabling tending of cache when status is Upkeep Required

### DIFF
--- a/esrc/process_tend.php
+++ b/esrc/process_tend.php
@@ -92,7 +92,7 @@ if (isset($_POST['sys_tend'])) {
 		{
 			$errmsg = $errmsg . "Cache has already been tended. Looks like someone else beat you to it!\n";
 		}
-		else if (($status === 'Expired' && $cacheInfo['Status'] == 'Expired') || ($status === 'Upkeep Required' && $cacheInfo['Status'] == 'Upkeep Required'))
+		else if (($status === 'Expired' && $cacheInfo['Status'] == 'Expired'))
 		{
 			$errmsg = $errmsg . "Could not set cache to '".Output::htmlEncodeString($status)."' as that is already its current status.\n";
 		}


### PR DESCRIPTION
Fix for this issue:
https://github.com/Thricehappy/EveScoutRescue/issues/211

Not entirely sure I've understood the problem correctly, but it does seem that it might be desirable for someone to tend a cache (and so reset the timer) even if they don't have the correct supplies to restock it.