### PR TITLE
Live ESRC Count

### DIFF
--- a/class/caches.class.php
+++ b/class/caches.class.php
@@ -40,7 +40,8 @@ class Caches
 	 */
 	public function getActiveCount()
 	{
-		$this->db->query("SELECT COUNT(*) as cnt FROM cache WHERE Status <> 'Expired'");
+		//$this->db->query("SELECT COUNT(*) as cnt FROM cache WHERE Status <> 'Expired'");
+		$this->db->query("SELECT cache_activity.Sown, cache_activity.Tended, cache_activity.ActiveCaches FROM cache_activity WHERE Sown IS NOT NULL ORDER BY ID DESC LIMIT 1");
 		$result = $this->db->single();
 		
 		$this->db->closeQuery();

--- a/esrc/stats_esrc.php
+++ b/esrc/stats_esrc.php
@@ -111,7 +111,7 @@ $leaderBoard = new Leaderboard($database);
 		<span class="sechead" style="font-weight: bold;">Total Active Caches:</span><br />
 		<span class="sechead"><?php echo $ctractive; ?> of 2603 
 			(<?php echo round((intval($ctractive)/2603)*100,1); ?>%)</span><br />
-			<?php echo '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' . gmdate('Y-m-d H:i:s', strtotime("now"));?><br />
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(as of last downtime)<br />
 		<br />
 		<span class="sechead">"No Sow" systems: <?php echo $lockedSys ?></span><br />
 		<span class="sechead">Expiring in <?=$expireDays?> days: <?php echo $toexpire; ?></span><br />
@@ -119,6 +119,6 @@ $leaderBoard = new Leaderboard($database);
 		<span class="sechead" style="font-weight: bold; color: gold;">All Time</span><br />
 		<span class="sechead">Sown: <?php echo $ctrsown; ?></span><br />
 		<span class="sechead">Tended: <?php echo $ctrtended; ?></span><br />
-		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(as of YC119-Mar-18)
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(since YC119-Mar-18)
 	</div>
 </div> 


### PR DESCRIPTION
Turn off live count of active rescue caches by pulling data from active_cache table instead of cache table